### PR TITLE
Remove system:authenticated from groups in read-only-scc.yaml 

### DIFF
--- a/Read-Only-FS/read-only-scc.yaml
+++ b/Read-Only-FS/read-only-scc.yaml
@@ -15,8 +15,7 @@ allowedFlexVolumes: null
 defaultAddCapabilities: null
 fsGroup:
   type: MustRunAs
-groups:
-- system:authenticated
+groups: []
 priority: null
 readOnlyRootFilesystem: true
 requiredDropCapabilities:


### PR DESCRIPTION
So that it does not override the existing default 'restricted' SCC.  Currently this will cause existing projects on a default OCP installation that rely on 'restricted' SCC with write permission to the filesystem to break because the priority of this read-only SCC is higher than that of the 'restricted one'.  